### PR TITLE
fix: change to -loader due to Webpack 2 change

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-require("style!css!less!./font-awesome-styles.loader!./font-awesome.config.js");
+require("style-loader!css-loader!less-loader!./font-awesome-styles.loader!./font-awesome.config.js");


### PR DESCRIPTION
- Change to `-loader` due to Webpack 2 breaking change in the latest release